### PR TITLE
doc: remove deprecated prettier in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ add plugin in prettier config. For example `.prettierrc`
 
 ```json
 {
-  "pluginSearchDirs": ["node_modules"],
   "plugins": ["assemblyscript-prettier"]
 }
 ```


### PR DESCRIPTION
In offical released prettier@3, `pluginSearchDirs` has been removed
